### PR TITLE
Fix/weaponsforge 48

### DIFF
--- a/client/pages/todo/create.js
+++ b/client/pages/todo/create.js
@@ -2,7 +2,8 @@ import { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { unwrapResult } from '@reduxjs/toolkit'
 import { useRouter } from 'next/router'
-import { createNewTodo, todosReset } from '@/store/todo/todoThunks'
+import { createNewTodo } from '@/store/todo/todoThunks'
+import { todosReset } from '@/store/todo/todoSlice'
 
 import TodoInputForm from '@/components/todo/inputform'
 

--- a/client/pages/todo/edit/[...id].js
+++ b/client/pages/todo/edit/[...id].js
@@ -2,7 +2,8 @@ import { useState, useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { unwrapResult } from '@reduxjs/toolkit'
 import { useRouter } from 'next/router'
-import { updateExistingTodo, todosReset, fetchTodo } from '@/store/todo/todoThunks'
+import { updateExistingTodo, fetchTodo } from '@/store/todo/todoThunks'
+import { todosReset } from '@/store/todo/todoSlice'
 
 import TodoInputForm from '@/components/todo/inputform'
 


### PR DESCRIPTION
### Update

- Fix the unresponsive **Clear** button on the `create new Todo` and `update existing Todo` pages. Use the correct file path reference for the `todosReset` action, [#48](https://github.com/weaponsforge/todo-next/issues/48)