### PR TITLE
Fix/weaponsforge 48

### DIFF
--- a/client/pages/todo/create.js
+++ b/client/pages/todo/create.js
@@ -53,7 +53,6 @@ function CreateTodoContainer () {
   }
 
   const handleReset = () => {
-    dispatch(todosReset())
     setState(defaultState)
   }
 

--- a/client/pages/todo/edit/[...id].js
+++ b/client/pages/todo/edit/[...id].js
@@ -72,7 +72,6 @@ function EditTodoContainer () {
   }
 
   const handleReset = () => {
-    dispatch(todosReset())
     setState(defaultState)
   }
 


### PR DESCRIPTION
### Update

- Press the **Clear** button only once to clear input on the `create` and `edit` **Todo** pages