### PR TITLE
feat: deploy development images to docker hub

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -115,3 +115,33 @@ jobs:
         run: |
           cd server
           rm -r -f .vercel
+
+  docker-build-push:
+    name: Push Image to Docker Hub
+    if: github.event.release.target_commitish == 'master' && vars.DOCKERHUB_USERNAME != ''
+    needs:
+      - lint-client
+      - lint-server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Create env variables
+        run: |
+          cp client/.env.example client/.env
+          cp server/.env.example server/.env
+
+      - name: Build Image
+        run: docker compose -f docker-compose.dev.yml build
+
+      - name: Push Image to Docker Hub
+        run: docker compose -f docker-compose.dev.yml push

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   lint-client:
     name: Lint and Export client
+    if: github.event.release.target_commitish == 'master'
     runs-on: ubuntu-latest
     env:
       NEXT_PUBLIC_BASE_PATH: ${{ secrets.NEXT_PUBLIC_BASE_PATH }}
@@ -50,6 +51,7 @@ jobs:
 
   lint-server:
     name: Lint Server
+    if: github.event.release.target_commitish == 'master'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
@@ -66,6 +68,7 @@ jobs:
 
   deploy-client:
     name: Deploy client to Github Pages
+    if: github.event.release.target_commitish == 'master'
     needs: lint-client
     runs-on: ubuntu-latest
     steps:
@@ -84,6 +87,7 @@ jobs:
 
   deploy-server:
     name: Deploy Server to Vercel
+    if: github.event.release.target_commitish == 'master'
     needs: lint-server
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/pull-images.yml
+++ b/.github/workflows/pull-images.yml
@@ -1,0 +1,26 @@
+# Pull the Docker images from Docker Hub on schedule
+name: Pull Docker Images
+
+on:
+  schedule:
+    # Runs "At 00:00 on day-of-month 1 in every 2nd month."
+    - cron: '0 0 1 */2 *'
+
+jobs:
+  pull-images:
+    name: Pull Development Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Fetch and check out latest tag
+        run: |
+          git fetch --tags
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "Checking out latest tag: $LATEST_TAG"
+          git checkout $LATEST_TAG
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+
+      - name: Pull Development Image
+        run: docker compose -f docker-compose.dev.yml pull

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 todo-next is a regular TO-DO notes listing app aimed for testing using NextJS and Redux Toolkit for front-end.<br>It also features a simple Todo CRUD API running on an express backend and uses mongodb for storing data.
 
+### Table of Contents
+
+- [Installation](#installation)
+- [Installation Using Docker](#installation-using-docker)
+- [Docker for Localhost Development](#docker-for-localhost-development)
+   - [Build Local Images](#build-local-images)
+   - [Use Pre-Built Development Images](#use-pre-built-development-images)
+   - [Seed MongoDB with Default Data](#seed-mongodb-with-default-data)
+   - [Docker Commands](#docker-commands)
+- [Deployment With GitHub Actions](#deployment-with-gitHub-actions)
+
 ## Installation
 
 1. Clone this repository.<br>

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The following dependencies are used to build and run the image. Please feel feel
 
 ### Docker for Localhost Development
 
+#### Build Local Images
+
 1. Set up the environment variables for the `/client` and `/server` directories.
    - Visit the `client/README.md` and `server/README.md` files for more information.
    - Take note of the `.env` variables setup for Windows and Linux to enable hot reload.
@@ -55,15 +57,41 @@ The following dependencies are used to build and run the image. Please feel feel
    # 5.3. Stop and remove the development containers, networks, images and volumes
    docker compose -f docker-compose.dev.yml down
    ```
-6. (Optional) To seed the container mongodb with default data:
-   - Create a `"/data/dump"` directory in the root project directory.
-   - Put binary data in the dump directory (data from `mongodump`)
-   - Start the development client and server containers (**# 5**)
-   - Run this script in another terminal (use GitBash if on Windows OS):<br>
-     ```bash
-     chmod u+x scripts/docker-mongo-seed.sh
-     ./scripts/docker-mongo-seed.sh
-     ```
+
+#### Use Pre-Built Development Images
+
+This project deploys the latest **client** and **server** development Docker images to Docker Hub on the creation of new Release/Tags. They are available at:
+
+https://hub.docker.com/r/weaponsforge/todo-next
+
+1. Pull the pre-built development Docker image using any of the two (2) options:
+   - Open a terminal and run:
+      ```
+      docker pull weaponsforge/todo-next:client
+      docker pull weaponsforge/todo-next:server
+      ```
+   - Navigate to the gsites-components root project directory, then run:
+      `docker compose -f docker-compose.dev.yml pull`
+
+2. Set up the environment variables for the `/client` and `/server` directories.
+   - Visit the `client/README.md` and `server/README.md` files for more information.
+   - Take note of the `.env` variables setup for Windows and Linux to enable hot reload.
+
+3. Run the development images.<br>
+`docker compose -f docker-compose.dev.yml up`
+
+#### Seed MongoDB with Default Data
+
+(Optional) To seed the container mongodb with default data:
+
+1. Create a `"/data/dump"` directory in the root project directory.
+2. Put binary data in the dump directory (data from `mongodump`)
+3. Start the development client and server containers (**# 5**)
+4. Run this script in another terminal (use GitBash if on Windows OS):<br>
+   ```bash
+   chmod u+x scripts/docker-mongo-seed.sh
+   ./scripts/docker-mongo-seed.sh
+   ```
 
 ### Docker for Production Deployment
 
@@ -101,6 +129,37 @@ The following docker-compose commands build a small client image targeted for cr
   - _(Directly from the command line):_<br>
     - `docker exec -it <MONGO_CONTAINER> mongorestore --host <SERVICE_NAME>:27017 -d <DB_NAME> -u <DB_USER> -p <DB_PASS> --authenticationDatabase <AUTH_SOURCE_FROM_URI> /data/dump`
     - `docker exec -it mongodb mongorestore --host mongo:27017 -d todo-next -u admin -p secret --authenticationDatabase admin /data/dump`
+
+## Deployment With GitHub Actions
+
+This project deploys the production live demo to GitHub Pages (front end) and Vercel (server). It uses MongoDB Atlas for MongoDB. The following requirements are optional. They are only required if there is a need to deploy the web application for live demonstration purposes.
+
+### Requirements
+
+1. GitHub Pages setup
+2. Vercel account
+   - pre-configured with a [stand-alone Express server](https://vercel.com/guides/using-express-with-vercel) of the repository's **server** component
+3. MongoDB Atlas database
+4. Docker Hub account
+   - (Optional) required to push the development images to Docker Hub
+
+#### GitHub Secrets
+
+| GitHub Secrets | Description |
+| --- | --- |
+| NEXT_PUBLIC_BASE_PATH | Root directory path name that NextJS uses for assets, media and client-side routing for the app.<br><br>Set its value to blank `''` when working on development mode in localhost.<br><br>Set its value to the sub-directory name where the exported NextJS app is to be deployed, i.e. `/<YOUR_REPOSITORY_NAME>` when<br> deploying on a repository (sub-directory) of a root GitHub Pages site, i.e, on `https://<YOUR_GITHUB_USERNAME>.github.io/<YOUR_REPOSITORY_NAME>` |
+| BASE_API_URL | 	Base URL of the Todo CRUD API from the `/server` directory. |
+| VERCEL_ORG_ID | Vercel app's organization ID |
+| VERCEL_PROJECT_ID | Vercel app's project ID |
+| VERCEL_TOKEN | Vercel app's project ID |
+| DOCKERHUB_USERNAME | (Optional) Docker Hub username. Required to enable pushing the development image to Docker Hub. |
+| DOCKERHUB_TOKEN | (Optional) Deploy token for the Docker Hub account. Required to enable pushing the development image to the Docker Hub. |
+
+#### GitHub Variables
+
+| GitHub Variable | Description |
+| --- | --- |
+| DOCKERHUB_USERNAME | (Optional) Docker Hub username. Required to enable pushing the development image to Docker Hub. |
 
 @weaponsforge<br>
 20220820<br>

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ The following docker-compose commands build a small client image targeted for cr
    - `docker ps -a`
 - **bash into the development mongodb container**<br>
    - `docker exec -it <MONGO_CONTAINER> /bin/sh`
+- **inspect the contents of an image**<br>
+   - `docker run -it --rm <IMAGE_NAME> /bin/sh`
 - **bash into the development mongodb shell**<br>
    - `docker exec -it <MONGO_CONTAINER> mongo -u <DB_USERNAME> -p <DB_PASS> <SERVICE_NAME>:27017/<DB_NAME> --authenticationDatabase <AUTH_SOURCE_FROM_URI>`
    - i.e. (see the .env.example and docker-compose.dev.yml files)<br> `docker exec -it mongodb mongo -u admin -p secret mongo:27017/todo-next --authenticationDatabase admin`
@@ -174,4 +176,4 @@ This project deploys the production live demo to GitHub Pages (front end) and Ve
 
 @weaponsforge<br>
 20220820<br>
-20240714
+20241004

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ services:
   # NextJS v13 app running on development mode
   todo-client-dev:
     container_name: todo-client-dev
-    image: weaponsforge/todo-client:dev
+    image: weaponsforge/todo-next:client
     depends_on:
       - todo-server-dev
     env_file:
@@ -23,7 +23,7 @@ services:
   # Express server running in development mode
   todo-server-dev:
     container_name: todo-server-dev
-    image: weaponsforge/todo-server:dev
+    image: weaponsforge/todo-next:server
     env_file:
       - ./server/.env
     build:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,7 @@ services:
       - "3000:3000"
 
   # Express web server app running in production mode
+  # Connects to remote MongoDB i.e., MongoDB Atlas
   todo-server-prod:
     container_name: todo-server-prod
     image: weaponsforge/todo-server:latest

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,10 +5,10 @@ API_WINDOW_MS_MINUTES=15
 DEPLOYMENT_PLATFORM=regular
 
 # Use this mongo URI without user/pass in local host's mongo
-MONGO_URI=mongodb://localhost/todo-next
+# MONGO_URI=mongodb://localhost/todo-next
 
 # Use this mongo URI when using user/pass in the docker-compose.dev YML
-# MONGO_URI=mongodb://admin:secret@mongo:27017/todo-next?authSource=admin
+MONGO_URI=mongodb://admin:secret@mongo:27017/todo-next?authSource=admin
 
 # Uncomment these 2 CHOKIDAR lines if using Docker Desktop and WSL2 on Windows OS
 # CHOKIDAR_USEPOLLING=true


### PR DESCRIPTION
- Feat: deploy the development **client** and **server** images to Docker Hub, [#62](https://github.com/weaponsforge/todo-next/issues/62) 
- Feat: pull the development images every 2 months to keep them active in the free Docker Hub account